### PR TITLE
:bug: fix(#36): upgrade the version of tags releases with renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "Pin All GitHub Actions",
+      "description": "Group all action pinning into one mass-update PR"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add renovate to track and update pinned SHAs in your GitHub Actions workflows.

## Metadata

| Field | Value |
|-------|-------|
| **Version** | x.x.x |
| **Author** | @alopesmendes |

## Type of Change

- [ ] 🚀 New feature
- [ ] 🐛 Fix
- [ ] 🔥 Hotfix
- [ ] 🧹 Chore
- [ ] 📚 Documentation

## Related Issues

Closes #36

## What's New or What Changed

- Add `renovate.json`

## User Impact

- Will create PR to update actions sha

## Checklist

- [ ] My code follows the project guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated the documentation accordingly
