### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Env.yml
+++ b/.github/workflows/Env.yml
@@ -31,6 +31,9 @@
 
 name: Environment
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/alopesmendes/SpringRetrievalAugmentedGeneration/security/code-scanning/26](https://github.com/alopesmendes/SpringRetrievalAugmentedGeneration/security/code-scanning/26)

To fix the problem, we should explicitly set a `permissions` block in the workflow to limit the `GITHUB_TOKEN` scope according to the principle of least privilege. Since the workflow primarily checks out code and runs a provided command, it does not need write access; read-only `contents` access is sufficient for `actions/checkout`. No other scopes (issues, pull-requests, etc.) are used directly in the shown snippet.

The best fix without changing existing functionality is to add a top-level `permissions` block so it applies to all jobs (`resolve` and `run`). This is done near the top of `.github/workflows/Env.yml`, alongside `name` and `on`. Specifically, after line 32 (`name: Environment`) and before the `on:` block, add:

```yaml
permissions:
  contents: read
```

This ensures that, unless a caller overrides it, both jobs will run with a GITHUB_TOKEN that can read repository contents but not write to them or access other privileged scopes. No additional imports or methods are required since this is a YAML configuration change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
